### PR TITLE
Fix PDF output and date validation

### DIFF
--- a/main_enhanced.py
+++ b/main_enhanced.py
@@ -943,7 +943,7 @@ class MagnusClientIntakeForm(QMainWindow):
             h_layout = QHBoxLayout()
             label = QLabel(f"{asset_type} (%):")
             spin_box = QSpinBox()
-            spin_box.setObjectName(f"asset_breakdown_{asset_type.lower().replace(\' \', \'_\')}")
+            spin_box.setObjectName(f"asset_breakdown_{asset_type.lower().replace(' ', '_')}")
             self.asset_breakdown_fields[asset_type] = spin_box
             
             h_layout.addWidget(label)
@@ -965,13 +965,13 @@ class MagnusClientIntakeForm(QMainWindow):
             
             year_label = QLabel("Year Started:")
             year_input = QLineEdit()
-            year_input.setObjectName(f"asset_experience_{exp_type.lower().replace(\' \', \'_\')}_year")
+            year_input.setObjectName(f"asset_experience_{exp_type.lower().replace(' ', '_')}_year")
             year_input.setPlaceholderText("YYYY")
             year_input.setMaximumWidth(80)
             
             level_label = QLabel("Level:")
             level_combo = QComboBox()
-            level_combo.setObjectName(f"asset_experience_{exp_type.lower().replace(\' \', \'_\')}_level")
+            level_combo.setObjectName(f"asset_experience_{exp_type.lower().replace(' ', '_')}_level")
             level_combo.addItems(["", "None", "Limited", "Good", "Extensive"])
             
             group_box_layout.addWidget(year_label)

--- a/pdf_generator_reportlab.py
+++ b/pdf_generator_reportlab.py
@@ -33,7 +33,7 @@ def generate_pdf_from_data(form_data, output_path):
         label_style = ParagraphStyle(
             'Label',
             parent=styles["Normal"],
-            fontName=\'Helvetica-Bold\',
+            fontName='Helvetica-Bold',
             fontSize=10,
             leading=12
         )
@@ -41,7 +41,7 @@ def generate_pdf_from_data(form_data, output_path):
         value_style = ParagraphStyle(
             'Value',
             parent=styles["Normal"],
-            fontName=\'Helvetica\',
+            fontName='Helvetica',
             fontSize=10,
             leading=12,
             leftIndent=20
@@ -159,12 +159,12 @@ def generate_pdf_from_data(form_data, output_path):
             
             t = Table(dependents_data, colWidths=[2*inch, 1.5*inch, 2*inch])
             t.setStyle(TableStyle([
-                (\'BACKGROUND\', (0, 0), (-1, 0), colors.lightgrey),
-                (\'TEXTCOLOR\', (0, 0), (-1, 0), colors.black),
-                (\'ALIGN\', (0, 0), (-1, -1), \'CENTER\'),
-                (\'FONTNAME\', (0, 0), (-1, 0), \'Helvetica-Bold\'),
-                (\'BOTTOMPADDING\', (0, 0), (-1, 0), 12),
-                (\'GRID\', (0, 0), (-1, -1), 1, colors.black)
+                ('BACKGROUND', (0, 0), (-1, 0), colors.lightgrey),
+                ('TEXTCOLOR', (0, 0), (-1, 0), colors.black),
+                ('ALIGN', (0, 0), (-1, -1), 'CENTER'),
+                ('FONTNAME', (0, 0), (-1, 0), 'Helvetica-Bold'),
+                ('BOTTOMPADDING', (0, 0), (-1, 0), 12),
+                ('GRID', (0, 0), (-1, -1), 1, colors.black)
             ]))
             content.append(t)
             content.append(Spacer(1, 0.2*inch))
@@ -181,18 +181,18 @@ def generate_pdf_from_data(form_data, output_path):
                     ben.get("name", ""),
                     ben.get("dob", ""),
                     ben.get("relationship", ""),
-                    f"{ben.get(\'percentage\', \'\')}".replace(\'%\', \'\') + "%"
+                    f"{ben.get('percentage', '')}".replace('%', '') + "%"
 
                 ])
             
             t = Table(beneficiaries_data, colWidths=[1.5*inch, 1.5*inch, 1.5*inch, 1*inch])
             t.setStyle(TableStyle([
-                (\'BACKGROUND\', (0, 0), (-1, 0), colors.lightgrey),
-                (\'TEXTCOLOR\', (0, 0), (-1, 0), colors.black),
-                (\'ALIGN\', (0, 0), (-1, -1), \'CENTER\'),
-                (\'FONTNAME\', (0, 0), (-1, 0), \'Helvetica-Bold\'),
-                (\'BOTTOMPADDING\', (0, 0), (-1, 0), 12),
-                (\'GRID\', (0, 0), (-1, -1), 1, colors.black)
+                ('BACKGROUND', (0, 0), (-1, 0), colors.lightgrey),
+                ('TEXTCOLOR', (0, 0), (-1, 0), colors.black),
+                ('ALIGN', (0, 0), (-1, -1), 'CENTER'),
+                ('FONTNAME', (0, 0), (-1, 0), 'Helvetica-Bold'),
+                ('BOTTOMPADDING', (0, 0), (-1, 0), 12),
+                ('GRID', (0, 0), (-1, -1), 1, colors.black)
             ]))
             content.append(t)
             content.append(Spacer(1, 0.2*inch))
@@ -222,13 +222,13 @@ def generate_pdf_from_data(form_data, output_path):
             
             t = Table(breakdown_data, colWidths=[3*inch, 1.5*inch])
             t.setStyle(TableStyle([
-                (\'BACKGROUND\', (0, 0), (-1, 0), colors.lightgrey),
-                (\'TEXTCOLOR\', (0, 0), (-1, 0), colors.black),
-                (\'ALIGN\', (0, 0), (-1, -1), \'LEFT\'),
-                (\'ALIGN\', (1, 0), (1, -1), \'CENTER\'),
-                (\'FONTNAME\', (0, 0), (-1, 0), \'Helvetica-Bold\'),
-                (\'BOTTOMPADDING\', (0, 0), (-1, 0), 12),
-                (\'GRID\', (0, 0), (-1, -1), 1, colors.black)
+                ('BACKGROUND', (0, 0), (-1, 0), colors.lightgrey),
+                ('TEXTCOLOR', (0, 0), (-1, 0), colors.black),
+                ('ALIGN', (0, 0), (-1, -1), 'LEFT'),
+                ('ALIGN', (1, 0), (1, -1), 'CENTER'),
+                ('FONTNAME', (0, 0), (-1, 0), 'Helvetica-Bold'),
+                ('BOTTOMPADDING', (0, 0), (-1, 0), 12),
+                ('GRID', (0, 0), (-1, -1), 1, colors.black)
             ]))
             content.append(t)
             content.append(Spacer(1, 0.1*inch))
@@ -248,12 +248,12 @@ def generate_pdf_from_data(form_data, output_path):
             
             t = Table(experience_data, colWidths=[2*inch, 1.5*inch, 2*inch])
             t.setStyle(TableStyle([
-                (\'BACKGROUND\', (0, 0), (-1, 0), colors.lightgrey),
-                (\'TEXTCOLOR\', (0, 0), (-1, 0), colors.black),
-                (\'ALIGN\', (0, 0), (-1, -1), \'LEFT\'),
-                (\'FONTNAME\', (0, 0), (-1, 0), \'Helvetica-Bold\'),
-                (\'BOTTOMPADDING\', (0, 0), (-1, 0), 12),
-                (\'GRID\', (0, 0), (-1, -1), 1, colors.black)
+                ('BACKGROUND', (0, 0), (-1, 0), colors.lightgrey),
+                ('TEXTCOLOR', (0, 0), (-1, 0), colors.black),
+                ('ALIGN', (0, 0), (-1, -1), 'LEFT'),
+                ('FONTNAME', (0, 0), (-1, 0), 'Helvetica-Bold'),
+                ('BOTTOMPADDING', (0, 0), (-1, 0), 12),
+                ('GRID', (0, 0), (-1, -1), 1, colors.black)
             ]))
             content.append(t)
             content.append(Spacer(1, 0.1*inch))
@@ -322,7 +322,7 @@ def generate_pdf_from_data(form_data, output_path):
         content.append(Paragraph("Regulatory Consent", heading_style))
         content.append(Spacer(1, 0.1*inch))
         electronic_consent = "Yes" if form_data.get("electronic_regulatory_yes") else "No"
-        content.append(Paragraph(f"<b>{label}:</b> {value}", normal_style))
+        content.append(Paragraph(f"<b>Electronic Delivery Consent:</b> {electronic_consent}", normal_style))
         content.append(Spacer(1, 0.05*inch))
 
         # Build the PDF

--- a/validation.py
+++ b/validation.py
@@ -6,7 +6,7 @@ Provides comprehensive validation with real-time feedback
 
 import re
 from typing import Dict, List, Any, Tuple, Optional
-from datetime import datetime
+from datetime import datetime, date
 
 class ValidationError(Exception):
     """Custom exception for validation errors"""


### PR DESCRIPTION
## Summary
- fix missing import for `date` in validation module
- correct f-string quoting in asset fields of main form
- clean PDF generator quoting and display electronic consent

## Testing
- `python -m py_compile main_enhanced.py pdf_generator_reportlab.py validation.py security.py package_app_enhanced.py`

------
https://chatgpt.com/codex/tasks/task_e_684aeb52449483308b99c0552265743a