### PR TITLE
Add QSS theme, review page, and hide console window

### DIFF
--- a/CREATE_INSTALLER.bat
+++ b/CREATE_INSTALLER.bat
@@ -16,7 +16,7 @@ echo.
 
 echo Step 2: Creating .exe file...
 if exist dist rd /s /q dist
-pyinstaller --noconfirm --onefile --name Magnus_Client_Intake_Form ^
+pyinstaller --noconfirm --onefile --noconsole --name Magnus_Client_Intake_Form ^
   --icon ICON.ico ^
   --collect-submodules PyQt6 --collect-data PyQt6 ^
   --add-data "ui;ui" --add-data "magnus_app;magnus_app" ^

--- a/magnus_app/app.py
+++ b/magnus_app/app.py
@@ -1,15 +1,18 @@
-if __package__ in (None, ""):
-    import os, sys  # noqa: E401
-    sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-    __package__ = "magnus_app"
 import sys
+from pathlib import Path
 from PyQt6.QtWidgets import QApplication
+from .main_window import MagnusClientIntakeForm
 
-from magnus_app.main_window import MagnusClientIntakeForm
+
+def _load_qss(app: QApplication) -> None:
+    qss = Path(__file__).with_name("theme.qss")
+    if qss.exists():
+        app.setStyleSheet(qss.read_text(encoding="utf-8"))
 
 
 def main() -> None:
     app = QApplication(sys.argv)
+    _load_qss(app)
     form = MagnusClientIntakeForm()
     form.show()
     sys.exit(app.exec())

--- a/magnus_app/theme.qss
+++ b/magnus_app/theme.qss
@@ -1,0 +1,45 @@
+/* Base */
+* { font-family: "Segoe UI", "Inter", system-ui; font-size: 11pt; }
+QMainWindow { background: #f7f8fa; }
+QScrollArea { background: transparent; border: none; }
+QWidget { background: transparent; }
+
+/* Group “cards” */
+QGroupBox {
+  background: #ffffff; border: 1px solid #e5e7eb; border-radius: 12px;
+  margin-top: 18px; padding: 12px 14px 14px 14px;
+}
+QGroupBox::title {
+  subcontrol-origin: margin; left: 12px; top: -10px;
+  background: #f7f8fa; padding: 2px 6px; color: #111827; font-weight: 600;
+}
+
+/* Inputs */
+QLineEdit, QTextEdit, QComboBox, QDateEdit {
+  background: #ffffff; border: 1px solid #cfd4dc; border-radius: 8px; padding: 8px;
+}
+QTextEdit { padding: 10px; }
+QLineEdit:focus, QTextEdit:focus, QComboBox:focus, QDateEdit:focus {
+  border: 1px solid #3b82f6; outline: none;
+}
+
+/* Buttons */
+QPushButton {
+  background: #1677ff; color: white; padding: 8px 16px; border-radius: 10px;
+  border: none; font-weight: 600;
+}
+QPushButton:hover { background: #0f62d9; }
+QPushButton:disabled { background: #a7b3c7; color: #eff2f6; }
+
+/* Secondary buttons (Back, Remove) */
+QPushButton[text*="Back"] { background: #6b7280; }
+QPushButton[text*="Remove"] { background: #ef4444; }
+
+/* Progress bar */
+QProgressBar {
+  background: #e5e7eb; border: none; border-radius: 8px; height: 18px; text-align: center;
+}
+QProgressBar::chunk { background-color: #3b82f6; border-radius: 8px; }
+
+/* Radio/checkbox spacing */
+QRadioButton, QCheckBox { padding: 4px 2px; }


### PR DESCRIPTION
## Summary
- Hide console window in Windows builds by adding `--noconsole` to installer script
- Apply modern QSS styling and autoload theme on startup
- Add Review & Submit page with state summary, Save Draft, and PDF generation

## Testing
- `python -m py_compile magnus_app/*.py`
- `python - <<'PY'
from magnus_app.pages import PAGES
print("page_count:", len(PAGES))
from magnus_app.app import main
print("app_import_ok")
PY` *(fails: ImportError: libGL.so.1)*
- `python -m magnus_app.app` *(fails: ImportError: libGL.so.1)*
- `echo Example PyInstaller: pyinstaller --noconsole --collect-all PyQt6 -F -n "Magnus Client Intake Form" magnus_app/app.py`


------
https://chatgpt.com/codex/tasks/task_e_689a143fd7908330a35dbfef5d477df9