### PR TITLE
Fix PDF generation by aligning API and UI handler

### DIFF
--- a/magnus_app/main_window.py
+++ b/magnus_app/main_window.py
@@ -194,54 +194,7 @@ class MagnusClientIntakeForm(QMainWindow):
         """
         self._review_text.setHtml(html)
 
-    def _generate_pdf(self) -> None:
-        if pdfgen is None or not hasattr(pdfgen, "generate"):
-            QMessageBox.warning(
-                self,
-                "PDF",
-                "PDF generator module not available.\n"
-                "Ensure magnus_app/pdf_generator_reportlab.py defines generate(state, path).",
-            )
-            return
-
-
-        # Summarize key sections (add more fields as needed)
-        lines += [
-            "PERSONAL INFORMATION:",
-            f"  Full Name: {get('full_name')}",
-            f"  Date of Birth: {get('dob')}",
-            f"  SSN: {get('ssn')}",
-            f"  Marital Status: {get('marital_status')}",
-            "",
-            "CONTACT INFORMATION:",
-            f"  Residential Address: {get('address')}",
-            f"  Email: {get('email')}",
-            f"  Mobile Phone: {get('phone_mobile')}",
-            "",
-            "EMPLOYMENT INFORMATION:",
-            f"  Status: {get('employment_status')}",
-            f"  Employer: {get('employer_name')}",
-            f"  Title: {get('job_title')}",
-            "",
-            "FINANCIAL INFORMATION:",
-            f"  Education: {get('education')}",
-            f"  Risk Tolerance: {get('risk_tolerance')}",
-            f"  Est. Net Worth: {get('est_net_worth')}",
-            f"  Est. Liquid Net Worth: {get('est_liquid_net_worth')}",
-            "",
-            "TRUSTED CONTACT:",
-            f"  Name: {get('tcp_full_name')}",
-            f"  Phone: {get('tcp_phone')}",
-            f"  Email: {get('tcp_email')}",
-            "",
-            "REGULATORY (highlights):",
-            f"  Employee of this BD: {get('employee_this_bd')}",
-            f"  SRO Member: {get('sro_member')}",
-            f"  Foreign FI Account: {get('has_ffi')}",
-            f"  PEP: {get('is_pep')}",
-        ]
-        self._review_text.setPlainText("\n".join(lines))
-
+    
     def _generate_pdf(self) -> None:
         if pdfgen is None or not hasattr(pdfgen, "generate"):
             QMessageBox.warning(self, "PDF", "PDF generator module not available.")
@@ -254,8 +207,6 @@ class MagnusClientIntakeForm(QMainWindow):
         try:
             pdfgen.generate(self.state, path)
             QMessageBox.information(self, "PDF", f"PDF generated successfully:\n{path}")
-            pdfgen.generate(self.state, path)  # adjust only if your function name differs
-            QMessageBox.information(self, "PDF", "PDF generated successfully.")
         except Exception as e:
             QMessageBox.critical(self, "PDF Error", f"Failed to generate PDF:\n{e}")
 

--- a/magnus_app/pdf_generator_reportlab.py
+++ b/magnus_app/pdf_generator_reportlab.py
@@ -544,3 +544,8 @@ def generate_pdf_report(form_data, output_path):
 
 # Alias for backward compatibility with main_enhanced.py
 generate_pdf_from_data = generate_pdf_report
+
+
+def generate(form_data, output_path):
+    """Compatibility wrapper expected by the UI."""
+    return generate_pdf_report(form_data, output_path)


### PR DESCRIPTION
## Summary
- Expose `generate` wrapper in `pdf_generator_reportlab` for UI compatibility
- Simplify `_generate_pdf` in main window and remove duplicate implementation

## Testing
- `python -m py_compile magnus_app/pdf_generator_reportlab.py magnus_app/main_window.py`


------
https://chatgpt.com/codex/tasks/task_e_689a221ad9ac833082e9dcdfa562d835