### PR TITLE
Enhance asset experience, electronic consent, and repeatable entries

### DIFF
--- a/magnus_app/main_window.py
+++ b/magnus_app/main_window.py
@@ -304,6 +304,7 @@ class MagnusClientIntakeForm(QMainWindow):
 
           <h4>REGULATORY (highlights)</h4>
           <p>
+            <b>Electronic Delivery Consent:</b> {get('electronic_delivery_consent')}<br/>
             <b>Employee of this BD:</b> {get('employee_this_bd')}<br/>
             <b>SRO Member:</b> {get('sro_member')}<br/>
             <b>Foreign FI Account:</b> {get('has_ffi')}<br/>
@@ -343,6 +344,33 @@ class MagnusClientIntakeForm(QMainWindow):
             if ftype == "radio":
                 btn = info["group"].checkedButton()
                 values[name] = btn.text() if btn else ""
+            elif ftype == "repeating_group":
+                items = []
+                for sub_inputs in info.get("items", []):
+                    item: Dict[str, Any] = {}
+                    for uniq, sinfo in sub_inputs.items():
+                        orig = sinfo.get("orig_name", uniq)
+                        stype = sinfo["type"]
+                        if stype == "radio":
+                            btn = sinfo["group"].checkedButton()
+                            val = btn.text() if btn else ""
+                        elif stype == "select":
+                            val = sinfo["widget"].currentText()
+                        elif stype in ("text", "number"):
+                            val = sinfo["widget"].text()
+                        elif stype == "date":
+                            val = sinfo["widget"].date().toString("yyyy-MM-dd")
+                        elif stype == "textarea":
+                            val = sinfo["widget"].toPlainText()
+                        elif stype == "checkbox":
+                            val = sinfo["widget"].isChecked()
+                        else:
+                            val = ""
+                        item[orig] = val
+                    # Only append if at least one field has data
+                    if any(v not in ("", False) for v in item.values()):
+                        items.append(item)
+                values[name] = items
             elif ftype == "select":
                 values[name] = info["widget"].currentText()
             elif ftype in ("text", "number"):

--- a/magnus_app/pages.py
+++ b/magnus_app/pages.py
@@ -330,25 +330,24 @@ PAGES: List[Dict[str, Any]] = [
                 'title': 'Dependents',
                 'fields': [
                     {
-                        'type': 'group',
-                        'name': 'dependent_block',
-
-                        'show_if': {'dependent_block': ''},
+                        'name': 'dependents',
+                        'type': 'repeating_group',
+                        'item_label': 'Dependent',
                         'fields': [
                             {
-                                'name': 'dep_full_name',
+                                'name': 'name',
                                 'type': 'text',
-                                'label': 'Dependent Full Name',
+                                'label': 'Full Name',
                                 'required': False,
                             },
                             {
-                                'name': 'dep_dob',
+                                'name': 'dob',
                                 'type': 'date',
-                                'label': 'Dependent Date of Birth',
+                                'label': 'Date of Birth',
                                 'required': False,
                             },
                             {
-                                'name': 'dep_relationship',
+                                'name': 'relationship',
                                 'type': 'text',
                                 'label': 'Relationship',
                                 'required': False,
@@ -367,31 +366,30 @@ PAGES: List[Dict[str, Any]] = [
                 'title': 'Beneficiaries',
                 'fields': [
                     {
-                        'type': 'group',
-                        'name': 'beneficiary_block',
-
-                        'show_if': {'beneficiary_block': ''},
+                        'name': 'beneficiaries',
+                        'type': 'repeating_group',
+                        'item_label': 'Beneficiary',
                         'fields': [
                             {
-                                'name': 'ben_full_name',
+                                'name': 'name',
                                 'type': 'text',
-                                'label': 'Beneficiary Full Name',
+                                'label': 'Full Name',
                                 'required': False,
                             },
                             {
-                                'name': 'ben_dob',
+                                'name': 'dob',
                                 'type': 'date',
-                                'label': 'Beneficiary Date of Birth',
+                                'label': 'Date of Birth',
                                 'required': False,
                             },
                             {
-                                'name': 'ben_relationship',
+                                'name': 'relationship',
                                 'type': 'text',
                                 'label': 'Relationship',
                                 'required': False,
                             },
                             {
-                                'name': 'ben_allocation_pct',
+                                'name': 'percentage',
                                 'type': 'number',
                                 'label': 'Allocation Percentage (%)',
                                 'required': False,
@@ -427,6 +425,7 @@ PAGES: List[Dict[str, Any]] = [
             {
                 'title': 'Investment Experience by Asset Type',
                 'fields': [
+                    {'name': 'label_stocks', 'type': 'label', 'label': 'Stocks'},
                     {
                         'name': 'stocks_year_started',
                         'type': 'text',
@@ -440,6 +439,7 @@ PAGES: List[Dict[str, Any]] = [
                         'required': False,
                         'options': ['None', 'Limited', 'Good', 'Extensive'],
                     },
+                    {'name': 'label_bonds', 'type': 'label', 'label': 'Bonds'},
                     {
                         'name': 'bonds_year_started',
                         'type': 'text',
@@ -453,6 +453,7 @@ PAGES: List[Dict[str, Any]] = [
                         'required': False,
                         'options': ['None', 'Limited', 'Good', 'Extensive'],
                     },
+                    {'name': 'label_mutual_funds', 'type': 'label', 'label': 'Mutual Funds'},
                     {
                         'name': 'mutual_funds_year_started',
                         'type': 'text',
@@ -466,6 +467,7 @@ PAGES: List[Dict[str, Any]] = [
                         'required': False,
                         'options': ['None', 'Limited', 'Good', 'Extensive'],
                     },
+                    {'name': 'label_uits', 'type': 'label', 'label': 'UITs'},
                     {
                         'name': 'uits_year_started',
                         'type': 'text',
@@ -479,6 +481,7 @@ PAGES: List[Dict[str, Any]] = [
                         'required': False,
                         'options': ['None', 'Limited', 'Good', 'Extensive'],
                     },
+                    {'name': 'label_annuities_fixed', 'type': 'label', 'label': 'Annuities (Fixed)'},
                     {
                         'name': 'annuities_fixed_year_started',
                         'type': 'text',
@@ -492,6 +495,7 @@ PAGES: List[Dict[str, Any]] = [
                         'required': False,
                         'options': ['None', 'Limited', 'Good', 'Extensive'],
                     },
+                    {'name': 'label_annuities_variable', 'type': 'label', 'label': 'Annuities (Variable)'},
                     {
                         'name': 'annuities_variable_year_started',
                         'type': 'text',
@@ -505,6 +509,7 @@ PAGES: List[Dict[str, Any]] = [
                         'required': False,
                         'options': ['None', 'Limited', 'Good', 'Extensive'],
                     },
+                    {'name': 'label_options', 'type': 'label', 'label': 'Options'},
                     {
                         'name': 'options_year_started',
                         'type': 'text',
@@ -518,6 +523,7 @@ PAGES: List[Dict[str, Any]] = [
                         'required': False,
                         'options': ['None', 'Limited', 'Good', 'Extensive'],
                     },
+                    {'name': 'label_commodities', 'type': 'label', 'label': 'Commodities'},
                     {
                         'name': 'commodities_year_started',
                         'type': 'text',
@@ -531,6 +537,7 @@ PAGES: List[Dict[str, Any]] = [
                         'required': False,
                         'options': ['None', 'Limited', 'Good', 'Extensive'],
                     },
+                    {'name': 'label_alternative_investments', 'type': 'label', 'label': 'Alternative Investments'},
                     {
                         'name': 'alternative_investments_year_started',
                         'type': 'text',
@@ -544,6 +551,7 @@ PAGES: List[Dict[str, Any]] = [
                         'required': False,
                         'options': ['None', 'Limited', 'Good', 'Extensive'],
                     },
+                    {'name': 'label_limited_partnerships', 'type': 'label', 'label': 'Limited Partnerships'},
                     {
                         'name': 'limited_partnerships_year_started',
                         'type': 'text',
@@ -557,6 +565,7 @@ PAGES: List[Dict[str, Any]] = [
                         'required': False,
                         'options': ['None', 'Limited', 'Good', 'Extensive'],
                     },
+                    {'name': 'label_variable_contracts', 'type': 'label', 'label': 'Variable Contracts'},
                     {
                         'name': 'variable_contracts_year_started',
                         'type': 'text',
@@ -605,6 +614,24 @@ PAGES: List[Dict[str, Any]] = [
                         'label': 'Email Address',
                         'required': False,
                     },
+                ],
+            }
+        ],
+    },
+    {
+        'key': 'reg_consent',
+        'title': 'Regulatory Consent',
+        'sections': [
+            {
+                'title': 'Electronic Delivery',
+                'fields': [
+                    {
+                        'name': 'electronic_delivery_consent',
+                        'type': 'radio',
+                        'label': 'Do you consent to electronic delivery of documents?',
+                        'required': True,
+                        'options': ['Yes', 'No'],
+                    }
                 ],
             }
         ],

--- a/magnus_app/pdf_generator_reportlab.py
+++ b/magnus_app/pdf_generator_reportlab.py
@@ -144,17 +144,23 @@ def save_draft_word(form_data, output_path):
         
         # Investment Experience
         doc.add_heading('Investment Experience', level=1)
-        experience_types = ["Stocks", "Bonds", "Mutual Funds", "ETFs", "Options", "Futures"]
-        for exp_type in experience_types:
-            year_field = f"asset_experience_{exp_type.lower().replace(' ', '_')}_year"
-            level_field = f"asset_experience_{exp_type.lower().replace(' ', '_')}_level"
-            
-            year = form_data.get(year_field)
-            level = form_data.get(level_field)
-            
-            doc.add_paragraph(f"{exp_type}:")
-            doc.add_paragraph(f"  Year Started: {year if year else '[Not provided]'}")
-            doc.add_paragraph(f"  Experience Level: {level if level else '[Not provided]'}")
+        asset_map = [
+            ("Stocks", "stocks"),
+            ("Bonds", "bonds"),
+            ("Mutual Funds", "mutual_funds"),
+            ("UITs", "uits"),
+            ("Annuities (Fixed)", "annuities_fixed"),
+            ("Annuities (Variable)", "annuities_variable"),
+            ("Options", "options"),
+            ("Commodities", "commodities"),
+            ("Alternative Investments", "alternative_investments"),
+            ("Limited Partnerships", "limited_partnerships"),
+            ("Variable Contracts", "variable_contracts"),
+        ]
+        for label, key in asset_map:
+            year = form_data.get(f"{key}_year_started")
+            level = form_data.get(f"{key}_level")
+            doc.add_paragraph(f"{label} – Year Started: {year if year else '[Not provided]'}, Level: {level if level else '[Not provided]'}")
             doc.add_paragraph()
         
         # Outside Broker Information
@@ -175,7 +181,7 @@ def save_draft_word(form_data, output_path):
         
         # Regulatory Consent
         doc.add_heading('Regulatory Consent', level=1)
-        electronic_consent = "Yes" if form_data.get("electronic_regulatory_yes", False) else "No"
+        electronic_consent = form_data.get("electronic_delivery_consent", "No") or "No"
         doc.add_paragraph(f"Electronic Delivery Consent: {electronic_consent}")
         
         # Save document
@@ -574,7 +580,7 @@ def generate_pdf_report(form_data, output_path):
 
         # Regulatory Consent
         content.append(Paragraph("Regulatory Consent", heading_style))
-        electronic_consent = "Yes" if form_data.get('electronic_regulatory_yes') else "No"
+        electronic_consent = form_data.get('electronic_delivery_consent', 'No') or 'No'
         content.append(Paragraph(f"Electronic Delivery Consent: {electronic_consent}", normal_style))
         
         # Add page numbers

--- a/magnus_app/renderer.py
+++ b/magnus_app/renderer.py
@@ -34,12 +34,17 @@ class PageRenderer:
     def iterate_fields(self, fields: List[Dict[str, Any]], values: Dict[str, Any]):
         """Yield field specs that should be validated based on show_if rules."""
         for fld in fields:
-            if fld.get("type") == "group":
+            ftype = fld.get("type")
+            if ftype in ("group", "repeating_group"):
+                # Groups (including repeating groups) may be conditionally shown
                 cond = fld.get("show_if") or {}
-                name, val = next(iter(cond.items()))
-                if values.get(name, "") == val:
-                    yield from self.iterate_fields(fld["fields"], values)
-            else:
+                if cond:
+                    name, val = next(iter(cond.items()))
+                    if values.get(name, "") != val:
+                        continue
+                # For validation we simply iterate over the child field specs
+                yield from self.iterate_fields(fld.get("fields", []), values)
+            elif ftype != "label":
                 cond = fld.get("show_if")
                 if cond:
                     name, val = next(iter(cond.items()))
@@ -65,10 +70,59 @@ class PageRenderer:
                 groups.append((container, field["show_if"]))
                 continue
 
+            if field.get("type") == "repeating_group":
+                container = QWidget()
+                vbox = QVBoxLayout(container)
+                item_inputs: List[Dict[str, Dict[str, Any]]] = []
+
+                def add_item(data: Dict[str, Any] | None = None) -> None:
+                    idx = len(item_inputs)
+                    box = QGroupBox(f"{field.get('item_label', 'Item')} {idx + 1}")
+                    box_layout = QVBoxLayout(box)
+                    sub_inputs: Dict[str, Dict[str, Any]] = {}
+                    for sub in field.get("fields", []):
+                        sub_name = sub.get("name")
+                        unique = f"{name}_{idx}_{sub_name}"
+                        sub_spec = dict(sub)
+                        sub_spec["name"] = unique
+                        # Pre-fill state if data provided
+                        if data:
+                            self.state[unique] = data.get(sub_name, "")
+                        self.render_fields([sub_spec], box_layout, sub_inputs, groups, on_change)
+                        # Remember original name for later extraction
+                        if unique in sub_inputs:
+                            sub_inputs[unique]["orig_name"] = sub_name
+                    item_inputs.append(sub_inputs)
+                    vbox.addWidget(box)
+
+                existing = self.state.get(name) or []
+                if existing:
+                    for item in existing:
+                        add_item(item)
+                else:
+                    add_item()
+
+                add_btn = QPushButton(f"Add Another {field.get('item_label', 'Item')}")
+                add_btn.clicked.connect(lambda: add_item())
+                vbox.addWidget(add_btn)
+
+                layout.addWidget(container)
+                inputs[name] = {
+                    "type": "repeating_group",
+                    "items": item_inputs,
+                }
+                continue
+
             ftype = field.get("type")
             name = field.get("name")
             label_text = field.get("label", name)
             widget: QWidget
+
+            if ftype == "label":
+                lab = QLabel(label_text)
+                lab.setWordWrap(True)
+                layout.addWidget(lab)
+                continue
 
             if ftype == "radio":
                 container = QWidget()

--- a/magnus_app/state.py
+++ b/magnus_app/state.py
@@ -11,11 +11,16 @@ def build_default_state() -> Dict[str, Any]:
 
     def walk(fields):
         for fld in fields:
-            if fld.get("type") == "group":
+            ftype = fld.get("type")
+            if ftype == "group":
                 walk(fld.get("fields", []))
                 continue
+            if ftype == "repeating_group":
+                state[fld.get("name")] = []
+                continue
+            if ftype == "label":
+                continue
             name = fld.get("name")
-            ftype = fld.get("type")
             if ftype == "radio":
                 state[name] = "No"
             elif ftype == "checkbox":


### PR DESCRIPTION
## Summary
- Add repeatable groups for dependents and beneficiaries with "Add Another" support.
- Label investment experience sections per asset and show labels in PDF and review.
- Introduce electronic delivery consent field and include in review and PDF output.

## Testing
- `python -m py_compile magnus_app/renderer.py magnus_app/state.py magnus_app/main_window.py magnus_app/pages.py magnus_app/pdf_generator_reportlab.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a3374a36083309dc4706a98f19d06