### PR TITLE
Add home page with recent draft support

### DIFF
--- a/REGISTER_FILE_ASSOC.bat
+++ b/REGISTER_FILE_ASSOC.bat
@@ -1,0 +1,14 @@
+@echo off
+setlocal
+set EXE="%~dp0dist\Magnus Client Intake Form.exe"
+if not exist %EXE% (
+  echo EXE not found at: %EXE%
+  echo Build the app first so the exe exists under /dist.
+  exit /b 1
+)
+set PROGID=MagnusClientIntake.Draft
+reg add "HKCU\Software\Classes\.mgd" /ve /d "%PROGID%" /f
+reg add "HKCU\Software\Classes\%PROGID%\DefaultIcon" /ve /d "%EXE%,0" /f
+reg add "HKCU\Software\Classes\%PROGID%\shell\open\command" /ve /d "\"%~dp0dist\\Magnus Client Intake Form.exe\" \"%%1\"" /f
+echo .mgd files now open with: %EXE%
+endlocal

--- a/magnus_app/app.py
+++ b/magnus_app/app.py
@@ -1,3 +1,4 @@
+import os
 import sys
 from pathlib import Path
 from PyQt6.QtGui import QPalette, QColor
@@ -25,7 +26,20 @@ def main() -> None:
     pal.setColor(QPalette.ColorRole.ButtonText, QColor("#ffffff"))
     app.setPalette(pal)
     _load_qss(app)
+
     form = MagnusClientIntakeForm()
+
+    arg_paths = [a for a in sys.argv[1:] if os.path.isfile(a)]
+    draft_path = next((p for p in arg_paths if p.lower().endswith((".mgd", ".json"))), None)
+
+    if draft_path:
+        try:
+            form.open_draft_path(draft_path)
+        except Exception:
+            form.show_home()
+    else:
+        form.show_home()
+
     form.show()
     sys.exit(app.exec())
 

--- a/magnus_app/home_page.py
+++ b/magnus_app/home_page.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import os
+from typing import List, Dict
+
+from PyQt6.QtCore import Qt, pyqtSignal
+from PyQt6.QtWidgets import (
+    QWidget, QVBoxLayout, QLabel, QPushButton, QHBoxLayout,
+    QTableWidget, QTableWidgetItem, QHeaderView
+)
+
+
+class HomePage(QWidget):
+    newRequested = pyqtSignal()
+    openDialogRequested = pyqtSignal()
+    openPathRequested = pyqtSignal(str)
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        layout = QVBoxLayout(self)
+
+        title = QLabel("Magnus Client Intake")
+        title.setObjectName("homeTitle")
+        layout.addWidget(title)
+
+        btn_row = QHBoxLayout()
+        new_btn = QPushButton("New Draft")
+        open_btn = QPushButton("Open…")
+        btn_row.addWidget(new_btn)
+        btn_row.addWidget(open_btn)
+        btn_row.addStretch()
+        layout.addLayout(btn_row)
+
+        self.table = QTableWidget(0, 3)
+        self.table.setObjectName("recentTable")
+        self.table.setHorizontalHeaderLabels(["Name", "Last Opened", "Path"])
+        self.table.horizontalHeader().setStretchLastSection(True)
+        self.table.horizontalHeader().setSectionResizeMode(0, QHeaderView.ResizeMode.ResizeToContents)
+        self.table.verticalHeader().setVisible(False)
+        self.table.setSelectionBehavior(QTableWidget.SelectionBehavior.SelectRows)
+        self.table.setEditTriggers(QTableWidget.EditTrigger.NoEditTriggers)
+        layout.addWidget(self.table, 1)
+
+        new_btn.clicked.connect(self.newRequested.emit)
+        open_btn.clicked.connect(self.openDialogRequested.emit)
+        self.table.cellDoubleClicked.connect(self._emit_open)
+
+    # ------------------------------------------------------------------ utils --
+    def refresh(self, items: List[Dict]) -> None:
+        self.table.setRowCount(0)
+        for item in items:
+            path = item.get("path", "")
+            name = os.path.basename(path)
+            last_opened = item.get("last_opened", "")
+            missing = not os.path.exists(path)
+
+            row = self.table.rowCount()
+            self.table.insertRow(row)
+
+            name_text = f"{name} (missing)" if missing else name
+            name_item = QTableWidgetItem(name_text)
+            name_item.setData(Qt.ItemDataRole.UserRole, path)
+            last_item = QTableWidgetItem(last_opened)
+            path_item = QTableWidgetItem(path)
+
+            if missing:
+                for it in (name_item, last_item, path_item):
+                    it.setToolTip("File not found")
+                    it.setForeground(Qt.GlobalColor.gray)
+
+            self.table.setItem(row, 0, name_item)
+            self.table.setItem(row, 1, last_item)
+            self.table.setItem(row, 2, path_item)
+
+    def _emit_open(self, row: int, _: int) -> None:
+        item = self.table.item(row, 0)
+        if not item:
+            return
+        path = item.data(Qt.ItemDataRole.UserRole)
+        if path:
+            self.openPathRequested.emit(path)

--- a/magnus_app/mru.py
+++ b/magnus_app/mru.py
@@ -1,0 +1,58 @@
+import json, os, tempfile, datetime, platform
+from typing import List, Dict
+
+_MAX = 10
+_FILE = "mru.json"
+
+
+def _base_dir() -> str:
+    sys = platform.system()
+    if sys == "Windows":
+        root = os.environ.get("APPDATA", os.path.expanduser("~"))
+        return os.path.join(root, "Magnus")
+    elif sys == "Darwin":
+        return os.path.join(os.path.expanduser("~/Library/Application Support"), "Magnus")
+    else:
+        return os.path.join(os.path.expanduser("~/.local/share"), "Magnus")
+
+def _path() -> str:
+    d = _base_dir()
+    os.makedirs(d, exist_ok=True)
+    return os.path.join(d, _FILE)
+
+def _now_str() -> str:
+    return datetime.datetime.now().strftime("%Y-%m-%d %H:%M")
+
+def get_mru() -> List[Dict]:
+    p = _path()
+    if not os.path.exists(p):
+        return []
+    try:
+        with open(p, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        if isinstance(data, list):
+            return data
+    except Exception:
+        pass
+    return []
+
+def _write_atomic(path: str, data: List[Dict]) -> None:
+    fd, tmp = tempfile.mkstemp(prefix=".tmp", dir=os.path.dirname(path))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            json.dump(data, fh, indent=2)
+        os.replace(tmp, path)
+    finally:
+        try:
+            os.remove(tmp)
+        except Exception:
+            pass
+
+def touch_mru(path: str) -> None:
+    items = [i for i in get_mru() if i.get("path") != path]
+    items.insert(0, {"path": path, "last_opened": _now_str()})
+    _write_atomic(_path(), items[:_MAX])
+
+def remove_from_mru(path: str) -> None:
+    items = [i for i in get_mru() if i.get("path") != path]
+    _write_atomic(_path(), items)

--- a/magnus_app/theme.qss
+++ b/magnus_app/theme.qss
@@ -101,3 +101,8 @@ QProgressBar::chunk { background-color: #3b82f6; border-radius: 8px; }
 
 /* Radio/checkbox spacing */
 QRadioButton, QCheckBox { padding: 4px 2px; }
+
+/* Home page */
+#homeTitle { font-size: 24px; font-weight: 700; margin: 24px 0 12px; }
+#recentTable { background: #ffffff; border: 1px solid #e5e7eb; }
+#recentTable::item:hover { background: #f1f5f9; }


### PR DESCRIPTION
## Summary
- Add MRU utilities to track and persist recently opened drafts
- Introduce Home page for starting new drafts and opening recent files
- Wire command-line file opening and default .mgd extension handling
- Provide Windows .mgd file association script and light home page styling

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689ab0339f388330a4aa54867e413178