### PR TITLE
feat: add session-aware home navigation

### DIFF
--- a/magnus_app/home_page.py
+++ b/magnus_app/home_page.py
@@ -23,6 +23,10 @@ class HomePage(QWidget):
         title.setObjectName("homeTitle")
         layout.addWidget(title)
 
+        header = QLabel("Home")
+        header.setObjectName("homeLabel")
+        layout.addWidget(header)
+
         btn_row = QHBoxLayout()
         new_btn = QPushButton("New Draft")
         open_btn = QPushButton("Open…")

--- a/magnus_app/renderer.py
+++ b/magnus_app/renderer.py
@@ -334,6 +334,7 @@ class PageRenderer:
         on_change: Callable[[], None],
         on_next: Callable[[], None],
         on_back: Callable[[], None],
+        on_home: Callable[[], None],
     ) -> Tuple[QWidget, Dict[str, Any]]:
         page = QWidget()
         layout = QVBoxLayout(page)
@@ -360,6 +361,10 @@ class PageRenderer:
         content_layout.addItem(QSpacerItem(0, 0, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding))
 
         nav = QHBoxLayout()
+        home_btn = QPushButton("Home")
+        home_btn.clicked.connect(on_home)
+        nav.addWidget(home_btn)
+
         if index > 0:
             back_btn = QPushButton("Back")
             back_btn.clicked.connect(on_back)


### PR DESCRIPTION
## Summary
- add session tracking and discard prompts only when needed
- introduce Home navigation via menu and wizard buttons
- start autosave only during active editing sessions

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689b1ccc737c833093e155516edb3801