### PR TITLE
Improve teardown robustness and crash logging

### DIFF
--- a/magnus_app/renderer.py
+++ b/magnus_app/renderer.py
@@ -223,12 +223,22 @@ class PageRenderer:
                         if vname == "usd_currency_0_1b":
                             num = parse_usd(text)
                             if num is not None:
-                                w.setText(format_usd(num))
+                                try:
+                                    w.blockSignals(True)
+                                    w.setText(format_usd(num))
+                                finally:
+                                    w.blockSignals(False)
+                                on_change()
                             ok = num is not None
                         elif vname == "percent_0_100":
                             num = parse_percent(text)
                             if num is not None:
-                                w.setText(format_percent(num))
+                                try:
+                                    w.blockSignals(True)
+                                    w.setText(format_percent(num))
+                                finally:
+                                    w.blockSignals(False)
+                                on_change()
                             ok = num is not None
                         else:
                             validator = self.validators.get(vname)
@@ -271,12 +281,22 @@ class PageRenderer:
                         if vname == "usd_currency_0_1b":
                             num = parse_usd(text)
                             if num is not None:
-                                w.setText(format_usd(num))
+                                try:
+                                    w.blockSignals(True)
+                                    w.setText(format_usd(num))
+                                finally:
+                                    w.blockSignals(False)
+                                on_change()
                             ok = num is not None
                         elif vname == "percent_0_100":
                             num = parse_percent(text)
                             if num is not None:
-                                w.setText(format_percent(num))
+                                try:
+                                    w.blockSignals(True)
+                                    w.setText(format_percent(num))
+                                finally:
+                                    w.blockSignals(False)
+                                on_change()
                             ok = num is not None
                         else:
                             validator = self.validators.get(vname)
@@ -400,12 +420,22 @@ class PageRenderer:
                     if vname == "usd_currency_0_1b":
                         num = parse_usd(text)
                         if num is not None:
-                            w.setText(format_usd(num))
+                            try:
+                                w.blockSignals(True)
+                                w.setText(format_usd(num))
+                            finally:
+                                w.blockSignals(False)
+                            set_value(w.text())
                         ok = num is not None
                     elif vname == "percent_0_100":
                         num = parse_percent(text)
                         if num is not None:
-                            w.setText(format_percent(num))
+                            try:
+                                w.blockSignals(True)
+                                w.setText(format_percent(num))
+                            finally:
+                                w.blockSignals(False)
+                            set_value(w.text())
                         ok = num is not None
                     else:
                         validator = self.validators.get(vname)
@@ -448,12 +478,22 @@ class PageRenderer:
                     if vname == "usd_currency_0_1b":
                         num = parse_usd(text)
                         if num is not None:
-                            w.setText(format_usd(num))
+                            try:
+                                w.blockSignals(True)
+                                w.setText(format_usd(num))
+                            finally:
+                                w.blockSignals(False)
+                            set_value(w.text())
                         ok = num is not None
                     elif vname == "percent_0_100":
                         num = parse_percent(text)
                         if num is not None:
-                            w.setText(format_percent(num))
+                            try:
+                                w.blockSignals(True)
+                                w.setText(format_percent(num))
+                            finally:
+                                w.blockSignals(False)
+                            set_value(w.text())
                         ok = num is not None
                     else:
                         validator = self.validators.get(vname)

--- a/magnus_app/state.py
+++ b/magnus_app/state.py
@@ -60,8 +60,19 @@ def load_state(path: str) -> Dict[str, Any]:
     return migrate_state(state)
 
 def save_state(path: str, state: Dict[str, Any]) -> None:
+    """Atomically persist *state* to *path*.
+
+    Writes to a temporary file and replaces the target on success. Any
+    exceptions are swallowed to avoid crashing the UI."""
+    if not path:
+        return
     try:
-        with open(path, "w", encoding="utf-8") as fh:
+        directory = os.path.dirname(path)
+        if directory:
+            os.makedirs(directory, exist_ok=True)
+        tmp = f"{path}.tmp"
+        with open(tmp, "w", encoding="utf-8") as fh:
             json.dump(state, fh, indent=2)
+        os.replace(tmp, path)
     except Exception:
         pass


### PR DESCRIPTION
## Summary
- Add global exception and Qt message logging to `crash.log`
- Guard navigation, autosave, and field changes during page teardown
- Switch save/open dialogs to non-native versions and ensure atomic saves
- Safely rebuild pages and sanitize repeating-group data when opening drafts
- Block and restore signals when formatting currency/percent inputs

## Testing
- `python -m py_compile magnus_app/app.py magnus_app/main_window.py magnus_app/renderer.py magnus_app/state.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689b3b5d644483308ff1120be7061da6