### PR TITLE
Stabilize session lifecycle and dialogs

### DIFF
--- a/magnus_app/theme.qss
+++ b/magnus_app/theme.qss
@@ -6,7 +6,7 @@ QMainWindow, QWidget { background: #f7f8fa; }
 
 /* Scroll surfaces */
 QScrollArea { background: #f7f8fa; border: none; }
-QScrollArea > QWidget > QWidget { background: #f7f8fa; } /* viewport chain */
+QScrollArea > QWidget > QWidget { background: #f7f8fa; }
 
 /* Cards (sections) */
 QGroupBox {
@@ -23,19 +23,6 @@ QGroupBox::title {
   padding: 2px 6px;
   color: #111827;
   font-weight: 600;
-* { font-family: "Segoe UI", "Inter", system-ui; font-size: 11pt; }
-QMainWindow { background: #f7f8fa; }
-QScrollArea { background: transparent; border: none; }
-QWidget { background: transparent; }
-
-/* Group “cards” */
-QGroupBox {
-  background: #ffffff; border: 1px solid #e5e7eb; border-radius: 12px;
-  margin-top: 18px; padding: 12px 14px 14px 14px;
-}
-QGroupBox::title {
-  subcontrol-origin: margin; left: 12px; top: -10px;
-  background: #f7f8fa; padding: 2px 6px; color: #111827; font-weight: 600;
 }
 
 /* Inputs */
@@ -50,12 +37,6 @@ QTextEdit { padding: 10px; }
 QLineEdit:focus, QTextEdit:focus, QComboBox:focus, QDateEdit:focus {
   border: 1px solid #3b82f6;
   outline: none;
-
-  background: #ffffff; border: 1px solid #cfd4dc; border-radius: 8px; padding: 8px;
-}
-QTextEdit { padding: 10px; }
-QLineEdit:focus, QTextEdit:focus, QComboBox:focus, QDateEdit:focus {
-  border: 1px solid #3b82f6; outline: none;
 }
 
 /* Buttons */
@@ -66,14 +47,11 @@ QPushButton {
   border-radius: 10px;
   border: none;
   font-weight: 600;
-  background: #1677ff; color: white; padding: 8px 16px; border-radius: 10px;
-  border: none; font-weight: 600;
 }
 QPushButton:hover { background: #0f62d9; }
 QPushButton:disabled { background: #a7b3c7; color: #eff2f6; }
 
 /* Secondary buttons */
-/* Secondary buttons (Back, Remove) */
 QPushButton[text*="Back"] { background: #6b7280; }
 QPushButton[text*="Remove"] { background: #ef4444; }
 
@@ -91,16 +69,9 @@ QProgressBar::chunk { background-color: #3b82f6; border-radius: 8px; }
 /* Radios/checkboxes */
 QRadioButton, QCheckBox { padding: 4px 2px; }
 
-/* Message boxes – force light background + readable text */
+/* Message boxes */
 QMessageBox { background: #ffffff; }
 QMessageBox QLabel { color: #111827; background: #ffffff; }
-
-  background: #e5e7eb; border: none; border-radius: 8px; height: 18px; text-align: center;
-}
-QProgressBar::chunk { background-color: #3b82f6; border-radius: 8px; }
-
-/* Radio/checkbox spacing */
-QRadioButton, QCheckBox { padding: 4px 2px; }
 
 /* Home page */
 #homeTitle { font-size: 24px; font-weight: 700; margin: 24px 0 12px; }


### PR DESCRIPTION
## Summary
- Guard saves and autosaves with session state and current page bounds
- Treat Review page as part of pages list and index navigation safely
- Add native Windows save dialog for PDF generation with fallback option
- Load QSS stylesheet via resource helper and clean theme rules

## Testing
- `python -m py_compile magnus_app/main_window.py magnus_app/app.py`


------
https://chatgpt.com/codex/tasks/task_e_689b4aa1a6708330bd4bcfc921152e1b