### PR TITLE
Remove asset breakdown and include beneficiary DOB in PDF

### DIFF
--- a/magnus_app/pages.py
+++ b/magnus_app/pages.py
@@ -433,12 +433,6 @@ PAGES: List[Dict[str, Any]] = [
                 'title': 'Asset Overview',
                 'fields': [
                     {
-                        'name': 'include_breakdown',
-                        'type': 'checkbox',
-                        'label': 'Include Asset Breakdown',
-                        'required': False,
-                    },
-                    {
                         'name': 'outside_broker_assets',
                         'type': 'checkbox',
                         'label': 'Do you have assets with an outside broker firm?',

--- a/magnus_app/validation.py
+++ b/magnus_app/validation.py
@@ -579,14 +579,6 @@ class FormValidator:
             self.add_error("Liquid Net Worth", "Please enter a valid numeric value")
             valid = False
         
-        # Validate asset breakdown if included
-        if data.get("include_breakdown", False):
-            breakdown = data.get("asset_breakdown", {})
-            if breakdown:
-                percentages = [v for v in breakdown.values() if isinstance(v, (int, float))]
-                if not self.validate_percentage_total("Asset Breakdown", percentages):
-                    valid = False
-        
         return valid
 
     def validate_annual_income(self, field_name: str, income: str) -> bool:

--- a/ui/pages/assets_investment.py
+++ b/ui/pages/assets_investment.py
@@ -23,41 +23,6 @@ def create_page(form):
         content_widget = QWidget()
         content_layout = QVBoxLayout(content_widget)
 
-        # Asset Breakdown (optional)
-        include_breakdown_checkbox = QCheckBox("Include Asset Breakdown")
-        include_breakdown_checkbox.setObjectName("include_breakdown")
-        include_breakdown_checkbox.stateChanged.connect(form.on_include_breakdown_changed)
-        content_layout.addWidget(include_breakdown_checkbox)
-
-        form.asset_breakdown_group = QGroupBox("Asset Breakdown")
-        form.asset_breakdown_group.setObjectName("asset_breakdown_group")
-        form.asset_breakdown_group.setVisible(False)
-
-        breakdown_layout = QVBoxLayout(form.asset_breakdown_group)
-        form.asset_breakdown_fields = {}
-
-        asset_types = [
-            "Stocks", "Bonds", "Mutual Funds", "ETFs", "UITs", 
-            "Annuities (Fixed)", "Annuities (Variable)", "Options", 
-            "Commodities", "Alternative Investments", "Limited Partnerships", 
-            "Variable Contracts", "Short-Term", "Other"
-        ]
-
-        for asset_type in asset_types:
-            h_layout = QHBoxLayout()
-            label = QLabel(f"{asset_type} (%):")
-            spin_box = QSpinBox()
-            spin_box.setObjectName(f"asset_breakdown_{asset_type.lower().replace(' ', '_').replace('(', '').replace(')', '')}")
-            spin_box.setRange(0, 100)
-            spin_box.setSuffix("%")
-
-            form.asset_breakdown_fields[asset_type] = spin_box
-            h_layout.addWidget(label)
-            h_layout.addWidget(spin_box)
-            breakdown_layout.addLayout(h_layout)
-
-        content_layout.addWidget(form.asset_breakdown_group)
-
         # Investment Experience by Asset Type
         experience_label = QLabel("Investment Experience by Asset Type:")
         experience_label.setStyleSheet("font-weight: bold; margin-top: 10px;")


### PR DESCRIPTION
## Summary
- remove asset breakdown option and related processing
- add beneficiary date of birth column and formatting to generated PDFs

## Testing
- `pytest`
- `python -m py_compile magnus_app/pdf_generator_reportlab.py ui/pages/assets_investment.py magnus_app/validation.py magnus_app/pages.py`


------
https://chatgpt.com/codex/tasks/task_e_689b70d64a708330a04d1e5e2aff8370