### PR TITLE
Add employer address field and trusted contact exports

### DIFF
--- a/magnus_app/main_window.py
+++ b/magnus_app/main_window.py
@@ -335,6 +335,7 @@ class MagnusClientIntakeForm(QMainWindow):
           <p>
             <b>Status:</b> {get('employment_status')}<br/>
             <b>Employer:</b> {get('employer_name')}<br/>
+            <b>Employer Address:</b> {get('employer_address')}<br/>
             <b>Title:</b> {get('job_title')}<br/>
             <b>Years with Employer:</b> {get('years_with_employer')}
           </p>
@@ -366,10 +367,10 @@ class MagnusClientIntakeForm(QMainWindow):
 
           <h4>TRUSTED CONTACT</h4>
           <p>
-            <b>Name:</b> {get('tcp_full_name')}<br/>
-            <b>Relationship:</b> {get('tcp_relationship')}<br/>
-            <b>Phone:</b> {get('tcp_phone')}<br/>
-            <b>Email:</b> {get('tcp_email')}
+            <b>Full Name:</b> {get('tc_full_name')}<br/>
+            <b>Relationship:</b> {get('tc_relationship')}<br/>
+            <b>Phone:</b> {get('tc_phone')}<br/>
+            <b>Email Address:</b> {get('tc_email')}
           </p>
 
           <h4>REGULATORY (highlights)</h4>

--- a/magnus_app/pages.py
+++ b/magnus_app/pages.py
@@ -133,6 +133,14 @@ PAGES: List[Dict[str, Any]] = [
                         'required': False,
                     },
                     {
+                        'type': 'textarea',
+                        'name': 'employer_address',
+                        'label': 'Employer Address',
+                        'placeholder': 'Street, City, State ZIP',
+                        'required': False,
+                        'max_len': 500,
+                    },
+                    {
                         'name': 'job_title',
                         'type': 'text',
                         'label': 'Occupation/Job Title',
@@ -620,21 +628,21 @@ PAGES: List[Dict[str, Any]] = [
                 'title': 'Trusted Contact Person',
                 'fields': [
                     {
-                        'name': 'tcp_full_name',
+                        'name': 'tc_full_name',
                         'type': 'text',
                         'label': 'Full Legal Name',
                         'required': False,
                         'validate': 'optional_person_name',
                     },
                     {
-                        'name': 'tcp_relationship',
+                        'name': 'tc_relationship',
                         'type': 'text',
                         'label': 'Relationship to You',
                         'required': False,
                         'validate': 'optional_person_name',
                     },
                     {
-                        'name': 'tcp_phone',
+                        'name': 'tc_phone',
                         'type': 'text',
                         'label': 'Phone Number',
                         'required': False,
@@ -642,7 +650,7 @@ PAGES: List[Dict[str, Any]] = [
                         'input_mask': 'phone',
                     },
                     {
-                        'name': 'tcp_email',
+                        'name': 'tc_email',
                         'type': 'text',
                         'label': 'Email Address',
                         'required': False,

--- a/magnus_app/pdf_generator_reportlab.py
+++ b/magnus_app/pdf_generator_reportlab.py
@@ -119,10 +119,10 @@ def save_draft_word(form_data, output_path):
         doc.add_heading('Employment Information', level=1)
         doc.add_paragraph(f"Employment Status: {form_data.get('employment_status', '[Not provided]')}")
         doc.add_paragraph(f"Employer Name: {form_data.get('employer_name', '[Not provided]')}")
+        doc.add_paragraph(f"Employer Address: {form_data.get('employer_address', '[Not provided]')}")
         doc.add_paragraph(f"Occupation/Title: {form_data.get('job_title', '[Not provided]')}")
         doc.add_paragraph(f"Years Employed: {form_data.get('years_with_employer', '[Not provided]')}")
         doc.add_paragraph(f"Annual Income: {fmt_usd(form_data.get('annual_income'))}")
-        doc.add_paragraph(f"Employer Address: {form_data.get('employer_address', '[Not provided]')}")
         
         # Retirement Information (if applicable)
         if form_data.get("employment_status") == "Retired":
@@ -222,10 +222,10 @@ def save_draft_word(form_data, output_path):
         
         # Trusted Contact Information
         doc.add_heading('Trusted Contact Information', level=1)
-        doc.add_paragraph(f"Full Name: {form_data.get('trusted_full_name', '[Not provided]')}")
-        doc.add_paragraph(f"Relationship: {form_data.get('trusted_relationship', '[Not provided]')}")
-        doc.add_paragraph(f"Phone Number: {form_data.get('trusted_phone', '[Not provided]')}")
-        doc.add_paragraph(f"Email Address: {form_data.get('trusted_email', '[Not provided]')}")
+        doc.add_paragraph(f"Full Name: {form_data.get('tc_full_name', '[Not provided]')}")
+        doc.add_paragraph(f"Relationship: {form_data.get('tc_relationship', '[Not provided]')}")
+        doc.add_paragraph(f"Phone Number: {form_data.get('tc_phone', '[Not provided]')}")
+        doc.add_paragraph(f"Email Address: {form_data.get('tc_email', '[Not provided]')}")
         doc.add_paragraph()
         
         # Regulatory Consent
@@ -305,7 +305,7 @@ def generate_pdf_report(form_data, output_path):
         )
 
         def safe(v):
-            return "" if v is None else str(v)
+            return "" if v is None else str(v).replace("\n", "<br/>")
 
         def field_row(label, value, is_currency=False):
             lbl = Paragraph(label, label_style)
@@ -377,10 +377,10 @@ def generate_pdf_report(form_data, output_path):
         add_section("Employment Information", [
             ("Employment Status", form_data.get("employment_status")),
             ("Employer Name", form_data.get("employer_name")),
+            ("Employer Address", form_data.get("employer_address")),
             ("Occupation/Title", form_data.get("job_title")),
             ("Years Employed", form_data.get("years_with_employer")),
             ("Annual Income", form_data.get("annual_income"), True),
-            ("Employer Address", form_data.get("employer_address")),
         ])
 
         add_section("Financial Information", [
@@ -490,10 +490,10 @@ def generate_pdf_report(form_data, output_path):
         ])
 
         add_section("Trusted Contact Information", [
-            ("Full Name", form_data.get("trusted_full_name")),
-            ("Relationship", form_data.get("trusted_relationship")),
-            ("Phone Number", form_data.get("trusted_phone")),
-            ("Email Address", form_data.get("trusted_email")),
+            ("Full Name", form_data.get("tc_full_name")),
+            ("Relationship", form_data.get("tc_relationship")),
+            ("Phone Number", form_data.get("tc_phone")),
+            ("Email Address", form_data.get("tc_email")),
         ])
 
         add_section("Regulatory Consent", [

--- a/magnus_app/renderer.py
+++ b/magnus_app/renderer.py
@@ -335,9 +335,26 @@ class PageRenderer:
 
             elif ftype == "textarea":
                 widget = QTextEdit()
+                widget.setPlaceholderText(field.get("placeholder", ""))
+                widget.setFixedHeight(80)
+                if "max_len" in field:
+                    def limit(w=widget, ml=int(field["max_len"])):
+                        txt = w.toPlainText()
+                        if len(txt) > ml:
+                            cursor = w.textCursor()
+                            pos = cursor.position()
+                            w.blockSignals(True)
+                            w.setPlainText(txt[:ml])
+                            cursor.setPosition(min(pos, ml))
+                            w.setTextCursor(cursor)
+                            w.blockSignals(False)
+                    widget.textChanged.connect(limit)
                 widget.setPlainText(self.state.get(name, ""))
-                widget.textChanged.connect(on_change)
-                widget.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
+                def on_change_text(w=widget, n=name):
+                    self.state[n] = w.toPlainText().strip()
+                    on_change()
+                widget.textChanged.connect(on_change_text)
+                widget.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
 
             elif ftype == "checkbox":
                 widget = QCheckBox(label_text)
@@ -535,9 +552,23 @@ class PageRenderer:
 
         elif ftype == "textarea":
             widget = QTextEdit()
+            widget.setPlaceholderText(sub_spec.get("placeholder", ""))
+            widget.setFixedHeight(80)
+            if "max_len" in sub_spec:
+                def limit(w=widget, ml=int(sub_spec["max_len"])):
+                    txt = w.toPlainText()
+                    if len(txt) > ml:
+                        cursor = w.textCursor()
+                        pos = cursor.position()
+                        w.blockSignals(True)
+                        w.setPlainText(txt[:ml])
+                        cursor.setPosition(min(pos, ml))
+                        w.setTextCursor(cursor)
+                        w.blockSignals(False)
+                widget.textChanged.connect(limit)
             widget.setPlainText(data.get(sub_name, ""))
-            widget.textChanged.connect(lambda: set_value(widget.toPlainText()))
-            widget.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
+            widget.textChanged.connect(lambda: set_value(widget.toPlainText().strip()))
+            widget.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
 
         elif ftype == "checkbox":
             widget = QCheckBox(label_text)

--- a/magnus_app/state.py
+++ b/magnus_app/state.py
@@ -65,6 +65,20 @@ def migrate_state(state: Dict[str, Any]) -> Dict[str, Any]:
     if "assets_held_away_total" not in state and "assets_held_away" in state:
         state["assets_held_away_total"] = state.pop("assets_held_away")
 
+    aliases = {
+        "trusted_full_name": "tc_full_name",
+        "trusted_relationship": "tc_relationship",
+        "trusted_phone": "tc_phone",
+        "trusted_email": "tc_email",
+        "tcp_full_name": "tc_full_name",
+        "tcp_relationship": "tc_relationship",
+        "tcp_phone": "tc_phone",
+        "tcp_email": "tc_email",
+    }
+    for old, new in aliases.items():
+        if old in state and new not in state:
+            state[new] = state[old]
+
     default = build_default_state()
     for k, v in default.items():
         state.setdefault(k, v)

--- a/magnus_app/validation.py
+++ b/magnus_app/validation.py
@@ -673,18 +673,18 @@ class FormValidator:
             return True  # Skip validation if not opted in
         
         # Required fields for trusted contact
-        if not self.validate_required_field("Trusted Contact Name", data.get("trusted_contact_name", "")):
+        if not self.validate_required_field("Trusted Contact Name", data.get("tc_full_name", "")):
             valid = False
-        
-        if not self.validate_required_field("Trusted Contact Relationship", data.get("trusted_contact_relationship", "")):
+
+        if not self.validate_required_field("Trusted Contact Relationship", data.get("tc_relationship", "")):
             valid = False
-        
+
         # Phone number validation
-        if not self.validate_phone("Trusted Contact Phone", data.get("trusted_contact_phone", "")):
+        if not self.validate_phone("Trusted Contact Phone", data.get("tc_phone", "")):
             valid = False
-        
+
         # Email validation (optional but if provided must be valid)
-        trusted_email = data.get("trusted_contact_email", "")
+        trusted_email = data.get("tc_email", "")
         if trusted_email and not self.validate_email("Trusted Contact Email", trusted_email):
             valid = False
         

--- a/ui/pages/trusted_contact.py
+++ b/ui/pages/trusted_contact.py
@@ -26,27 +26,27 @@ def create_page(form):
 
     # Trusted Contact Name
     layout.addWidget(QLabel("Full Legal Name:"))
-    trusted_name_input = EnhancedLineEdit("trusted_full_name")
-    trusted_name_input.setObjectName("trusted_full_name")
+    trusted_name_input = EnhancedLineEdit("tc_full_name")
+    trusted_name_input.setObjectName("tc_full_name")
     layout.addWidget(trusted_name_input)
 
     # Trusted Contact Relationship
     layout.addWidget(QLabel("Relationship to You:"))
-    trusted_relationship_input = EnhancedLineEdit("trusted_relationship")
-    trusted_relationship_input.setObjectName("trusted_relationship")
+    trusted_relationship_input = EnhancedLineEdit("tc_relationship")
+    trusted_relationship_input.setObjectName("tc_relationship")
     layout.addWidget(trusted_relationship_input)
 
     # Trusted Contact Phone
     layout.addWidget(QLabel("Phone Number:"))
-    trusted_phone_input = EnhancedLineEdit("trusted_phone")
-    trusted_phone_input.setObjectName("trusted_phone")
+    trusted_phone_input = EnhancedLineEdit("tc_phone")
+    trusted_phone_input.setObjectName("tc_phone")
     trusted_phone_input.setPlaceholderText("(XXX) XXX-XXXX")
     layout.addWidget(trusted_phone_input)
 
     # Trusted Contact Email
     layout.addWidget(QLabel("Email Address:"))
-    trusted_email_input = EnhancedLineEdit("trusted_email")
-    trusted_email_input.setObjectName("trusted_email")
+    trusted_email_input = EnhancedLineEdit("tc_email")
+    trusted_email_input.setObjectName("tc_email")
     trusted_email_input.setPlaceholderText("example@email.com")
     layout.addWidget(trusted_email_input)
 


### PR DESCRIPTION
## Summary
- add Employer Address multiline field with state, review and export support
- render and export Trusted Contact info with canonical field names
- enhance textarea widget with placeholders and length limits

## Testing
- `pytest` (no tests ran)


------
https://chatgpt.com/codex/tasks/task_e_689b7721292c83308e2da3a35f52fc83