### PR TITLE
Add date formatting and opt-out controls

### DIFF
--- a/magnus_app/mru.py
+++ b/magnus_app/mru.py
@@ -21,7 +21,7 @@ def _path() -> str:
     return os.path.join(d, _FILE)
 
 def _now_str() -> str:
-    return datetime.datetime.now().strftime("%Y-%m-%d %H:%M")
+    return datetime.datetime.now().strftime("%m/%d/%Y %H:%M")
 
 def get_mru() -> List[Dict]:
     p = _path()

--- a/magnus_app/pages.py
+++ b/magnus_app/pages.py
@@ -347,9 +347,16 @@ PAGES: List[Dict[str, Any]] = [
                 'title': 'Dependents',
                 'fields': [
                     {
+                        'name': 'no_dependents',
+                        'type': 'checkbox',
+                        'label': 'I do not have dependents',
+                        'required': False,
+                    },
+                    {
                         'name': 'dependents',
                         'type': 'repeating_group',
                         'item_label': 'Dependent',
+                        'show_if': {'no_dependents': False},
                         'fields': [
                             {
                                 'name': 'full_name',
@@ -386,9 +393,16 @@ PAGES: List[Dict[str, Any]] = [
                 'title': 'Beneficiaries',
                 'fields': [
                     {
+                        'name': 'no_beneficiaries',
+                        'type': 'checkbox',
+                        'label': 'I do not wish to list beneficiaries at this time',
+                        'required': False,
+                    },
+                    {
                         'name': 'beneficiaries',
                         'type': 'repeating_group',
                         'item_label': 'Beneficiary',
+                        'show_if': {'no_beneficiaries': False},
                         'fields': [
                             {
                                 'name': 'full_name',
@@ -628,33 +642,45 @@ PAGES: List[Dict[str, Any]] = [
                 'title': 'Trusted Contact Person',
                 'fields': [
                     {
-                        'name': 'tc_full_name',
-                        'type': 'text',
-                        'label': 'Full Legal Name',
+                        'name': 'no_trusted_contact',
+                        'type': 'checkbox',
+                        'label': 'I do not wish to provide a trusted contact person',
                         'required': False,
-                        'validate': 'optional_person_name',
                     },
                     {
-                        'name': 'tc_relationship',
-                        'type': 'text',
-                        'label': 'Relationship to You',
-                        'required': False,
-                        'validate': 'optional_person_name',
-                    },
-                    {
-                        'name': 'tc_phone',
-                        'type': 'text',
-                        'label': 'Phone Number',
-                        'required': False,
-                        'validate': 'phone_us',
-                        'input_mask': 'phone',
-                    },
-                    {
-                        'name': 'tc_email',
-                        'type': 'text',
-                        'label': 'Email Address',
-                        'required': False,
-                        'validate': 'email_basic',
+                        'type': 'group',
+                        'show_if': {'no_trusted_contact': False},
+                        'fields': [
+                            {
+                                'name': 'tc_full_name',
+                                'type': 'text',
+                                'label': 'Full Legal Name',
+                                'required': False,
+                                'validate': 'optional_person_name',
+                            },
+                            {
+                                'name': 'tc_relationship',
+                                'type': 'text',
+                                'label': 'Relationship to You',
+                                'required': False,
+                                'validate': 'optional_person_name',
+                            },
+                            {
+                                'name': 'tc_phone',
+                                'type': 'text',
+                                'label': 'Phone Number',
+                                'required': False,
+                                'validate': 'phone_us',
+                                'input_mask': 'phone',
+                            },
+                            {
+                                'name': 'tc_email',
+                                'type': 'text',
+                                'label': 'Email Address',
+                                'required': False,
+                                'validate': 'email_basic',
+                            },
+                        ],
                     },
                 ],
             }

--- a/magnus_app/renderer.py
+++ b/magnus_app/renderer.py
@@ -320,7 +320,7 @@ class PageRenderer:
 
             elif ftype == "date":
                 widget = QDateEdit()
-                widget.setDisplayFormat("yyyy-MM-dd")
+                widget.setDisplayFormat("MM/dd/yyyy")
                 widget.setCalendarPopup(True)
                 val = self.state.get(name, "")
                 if val:
@@ -537,7 +537,7 @@ class PageRenderer:
 
         elif ftype == "date":
             widget = QDateEdit()
-            widget.setDisplayFormat("yyyy-MM-dd")
+            widget.setDisplayFormat("MM/dd/yyyy")
             widget.setCalendarPopup(True)
             val = data.get(sub_name, "")
             if val:

--- a/ui/pages/personal_info.py
+++ b/ui/pages/personal_info.py
@@ -23,6 +23,7 @@ def create_page(form):
     layout.addWidget(QLabel("Date of Birth:"))
     dob_input = QDateEdit()
     dob_input.setObjectName("dob")
+    dob_input.setDisplayFormat("MM/dd/yyyy")
     dob_input.setDate(QDate.currentDate().addYears(-30))
     dob_input.setCalendarPopup(True)
     dob_input.setStyleSheet("""

--- a/ui/pages/spouse_info.py
+++ b/ui/pages/spouse_info.py
@@ -30,6 +30,7 @@ def create_page(form):
         layout.addWidget(QLabel("Date of Birth:"))
         spouse_dob_input = QDateEdit()
         spouse_dob_input.setObjectName("spouse_dob")
+        spouse_dob_input.setDisplayFormat("MM/dd/yyyy")
         spouse_dob_input.setDate(QDate.currentDate().addYears(-30))
         spouse_dob_input.setCalendarPopup(True)
         spouse_dob_input.setStyleSheet("""


### PR DESCRIPTION
## Summary
- Format all date pickers and report output as MM/DD/YYYY
- Allow users to opt out of providing dependents, beneficiaries, or a trusted contact
- Update review and reports to respect opt-outs

## Testing
- `python -m py_compile magnus_app/main_window.py magnus_app/mru.py magnus_app/pages.py magnus_app/pdf_generator_reportlab.py magnus_app/renderer.py ui/pages/personal_info.py ui/pages/spouse_info.py`


------
https://chatgpt.com/codex/tasks/task_e_68a3f4fa92d08330aaf3afcfcb443dfd